### PR TITLE
Allow override of API endpoint

### DIFF
--- a/.tekton/listener.yaml
+++ b/.tekton/listener.yaml
@@ -8,6 +8,8 @@ spec:
       description: The git repo
     - name: apikey
       description: the ibmcloud api key
+    - name: api
+      description: the ibmcloud api
     - name: registryNamespace
       description: the ibmcloud registry namespace
     - name: registryRegion
@@ -36,6 +38,8 @@ spec:
           value: $(params.repository)
         - name: apikey
           value: $(params.apikey)
+        - name: api
+          value: $(params.api)
         - name: registryNamespace
           value: $(params.registryNamespace)
         - name: registryRegion

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -10,6 +10,8 @@ spec:
       description: the git repo
     - name: apikey
       description: the ibmcloud api key
+    - name: api
+      description: the ibmcloud api endpoint
     - name: registryNamespace
       description: the ibmcloud registry namespace
     - name: cluster
@@ -32,6 +34,8 @@ spec:
           value: $(params.pipeline-pvc)
         - name: repository
           value: $(params.repository)
+        - name: api
+          value: $(params.api)
         - name: apikey
           value: $(params.apikey)
         - name: registryNamespace
@@ -47,6 +51,8 @@ spec:
           value: $(params.pipeline-pvc)
         - name: repository
           value: $(params.repository)
+        - name: api
+          value: $(params.api)
         - name: apikey
           value: $(params.apikey)
         - name: registryRegion
@@ -60,6 +66,8 @@ spec:
           value: $(params.pipeline-pvc)
         - name: repository
           value: $(params.repository)
+        - name: api
+          value: $(params.api)
         - name: apikey
           value: $(params.apikey)
         - name: cluster

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -42,7 +42,7 @@ spec:
       env:
         - name: IBMCLOUD_API_KEY
           value: $(inputs.params.apikey)
-        - name: API
+        - name: APIURL
           value: $(inputs.params.api)
         - name: REGION
           value: $(inputs.params.registryRegion)
@@ -55,7 +55,7 @@ spec:
       command: ["/bin/bash", "-c"]
       args:
         - set -e -o pipefail;
-          ibmcloud login -a $API -r $REGION;
+          ibmcloud login -a $APIURL -r $REGION;
           export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh";
           source pre-build-check.sh;
       volumeMounts:
@@ -66,7 +66,7 @@ spec:
       env:
         - name: IBMCLOUD_API_KEY
           value: $(inputs.params.apikey)
-        - name: API
+        - name: APIURL
           value: $(inputs.params.api)
         - name: REGION
           value: $(inputs.params.registryRegion)
@@ -85,7 +85,7 @@ spec:
       command: ["/bin/bash", "-c"]
       args:
         - set -e -o pipefail;
-          ibmcloud login -a $API -r $REGION;
+          ibmcloud login -a $APIURL -r $REGION;
           export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh";
           export GIT_COMMIT=$(git rev-parse HEAD);
           export REGISTRY_URL=$(ibmcloud cr info | sed "2q;d" | awk '{for(i=1;i<=NF;i++) if ($i=="Registry") print $(i+1)}');
@@ -137,7 +137,7 @@ spec:
       env:
         - name: IBMCLOUD_API_KEY
           value: $(inputs.params.apikey)
-        - name: API
+        - name: APIURL
           value: $(inputs.params.api)
         - name: HOME
           value: "/root"
@@ -146,7 +146,7 @@ spec:
       command: ["/bin/bash", "-c"]
       args:
         - set -e -o pipefail;
-          ibmcloud login -a $API -r $REGION;
+          ibmcloud login -a $APIURL -r $REGION;
           while read line; do export $line; done < /artifacts/build.properties;
           cp /artifacts/build.properties .;
           source check-vulnerabilities.sh || true;
@@ -203,7 +203,7 @@ spec:
       env:
         - name: IBMCLOUD_API_KEY
           value: $(inputs.params.apikey)
-        - name: API
+        - name: APIURL
           value: $(inputs.params.api)
         - name: REGION
           value: $(inputs.params.clusterRegion)
@@ -218,7 +218,7 @@ spec:
       command: ["/bin/bash", "-c"]
       args:
         - set -e -o pipefail;
-          ibmcloud login -a $API -r $REGION;
+          ibmcloud login -a $APIURL -r $REGION;
           $(ibmcloud ks cluster config --cluster "${PIPELINE_KUBERNETES_CLUSTER_NAME}" --export);
           while read line; do export $line; done < /artifacts/build.properties;
           cp /artifacts/build.properties .;
@@ -231,7 +231,7 @@ spec:
       env:
         - name: IBMCLOUD_API_KEY
           value: $(inputs.params.apikey)
-        - name: API
+        - name: APIURL
           value: $(inputs.params.api)
         - name: REGION
           value: $(inputs.params.clusterRegion)
@@ -246,7 +246,7 @@ spec:
       command: ["/bin/bash", "-c"]
       args:
         - set -e -o pipefail;
-          ibmcloud login -a $API -r $REGION;
+          ibmcloud login -a $APIURL -r $REGION;
           $(ibmcloud ks cluster config --cluster "${PIPELINE_KUBERNETES_CLUSTER_NAME}" --export);
           while read line; do export $line; done < /artifacts/build.properties;
           cp /artifacts/build.properties .;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -16,7 +16,7 @@ spec:
         description: the ibmcloud api key
       - name: api
         description: the ibmcloud api endpoint
-        default: "https://cloud.ibm.com"
+        default: "https://dev.console.test.cloud.ibm.com"
       - name: registryNamespace
         description: the ibmcloud registry namespace
       - name: imageName

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -116,7 +116,7 @@ spec:
         description: the ibmcloud api key
       - name: api
         description: the ibmcloud api endpoint
-        default: "https://cloud.ibm.com"
+        default: "https://dev.console.test.cloud.ibm.com"
       - name: registryRegion
         description: the ibmcloud registry region           
   steps:
@@ -176,7 +176,7 @@ spec:
         description: the ibmcloud api key
       - name: api
         description: the ibmcloud api endpoint
-        default: "https://cloud.ibm.com"
+        default: "https://dev.console.test.cloud.ibm.com"
       - name: deployment-file
         default: deployment.yml
       - name: clusterNamespace

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -16,7 +16,7 @@ spec:
         description: the ibmcloud api key
       - name: api
         description: the ibmcloud api endpoint
-        default: "https://dev.console.test.cloud.ibm.com"
+        default: "https://cloud.ibm.com"
       - name: registryNamespace
         description: the ibmcloud registry namespace
       - name: imageName
@@ -116,7 +116,7 @@ spec:
         description: the ibmcloud api key
       - name: api
         description: the ibmcloud api endpoint
-        default: "https://dev.console.test.cloud.ibm.com"
+        default: "https://cloud.ibm.com"
       - name: registryRegion
         description: the ibmcloud registry region           
   steps:
@@ -176,7 +176,7 @@ spec:
         description: the ibmcloud api key
       - name: api
         description: the ibmcloud api endpoint
-        default: "https://dev.console.test.cloud.ibm.com"
+        default: "https://cloud.ibm.com"
       - name: deployment-file
         default: deployment.yml
       - name: clusterNamespace


### PR DESCRIPTION
This allows for a property to be defined in the pipeline config that will override the API endpoint used during pipeline runs